### PR TITLE
Call python3 instead of python

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -129,11 +129,11 @@ export async function runPythonCommand(cmdArgs: string[]): Promise<string> {
     });
 }
 export async function runJupytext(cmdArgs: string[]): Promise<string> {
-    return runPythonCommand(['python'].concat(cmdArgs));
+    return runPythonCommand(['python3'].concat(cmdArgs));
 }
 async function testPythonCommand(): Promise<boolean> {
     const cmd = [
-        'python',
+        'python3',
         'c',
         'import sys;print(sys.executable);print(sys.version)',
     ];


### PR DESCRIPTION
Hacky fix for issue where python points to python 2.7 on MacOS.  Is there a better way to get the default python interpreter that VS Code would normally use?