### PR TITLE
Expose "Open as a Jupyter Notebook" in more places

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marke
 * Please install VS Code Insiders (stable is not yet supported)
 * Install this extension
 * Launch VS Code with the following command line `code-insiders --enable-proposed-api=donjayamanne.vscode-jupytext`
-* Right click a file and select `Open as a Jupyter Notebook`
+* Run the `Open as a Jupyter Notebook` from the context menu or editor title menu bar for a `*.py` file
 * Start executing code against Jupyter Kernels, save changes to notebook will result in the corresponding script file getting updated.
 
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
         "theme": "dark"
     },
     "activationEvents": [
-        "onCommand:jupyter.openAsPairedNotebook",
-        "onNotebook:jupyter-notebook",
-        "onFileSystem:jupytext"
+        "onStartupFinished"
     ],
     "main": "./dist/extension.js",
     "capabilities": {
@@ -57,47 +55,26 @@
             "explorer/context": [
                 {
                     "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == python"
-                },
+                    "when": "resourceLangId in vscode-jupytext.resourceLangIds"
+                }
+            ],
+            "editor/context": [
                 {
                     "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == r"
-                },
+                    "when": "resourceLangId in vscode-jupytext.resourceLangIds"
+                }
+            ],
+            "editor/title": [
                 {
                     "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == julia"
-                },
+                    "when": "resourceLangId in vscode-jupytext.resourceLangIds",
+                    "group": "navigation"
+                }
+            ],
+            "editor/title/context": [
                 {
                     "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == fsharp"
-                },
-                {
-                    "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == csharp"
-                },
-                {
-                    "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == java"
-                },
-                {
-                    "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == powershell"
-                },
-                {
-                    "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == typescript"
-                },
-                {
-                    "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == javascript"
-                },
-                {
-                    "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == markdown"
-                },
-                {
-                    "command": "jupyter.openAsPairedNotebook",
-                    "when": "resourceLangId == rust"
+                    "when": "resourceLangId in vscode-jupytext.resourceLangIds"
                 }
             ]
         }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,6 +3,23 @@ import { JupyterNotebookView, jupytextScheme } from './constants';
 import { convertToNotebook } from './conversion';
 
 export function initialize() {
+    commands.executeCommand(
+        'setContext',
+        'vscode-jupytext.resourceLangIds',
+        [
+            'csharp',
+            'fsharp',
+            'java',
+            'javascript',
+            'julia',
+            'markdown',
+            'powershell',
+            'python',
+            'r',
+            'rust',
+            'typescript'
+        ]);
+
     commands.registerCommand('jupyter.openAsPairedNotebook', async (uri?: Uri) => {
         uri = uri || window.activeTextEditor?.document.uri ;
         if (!uri){


### PR DESCRIPTION
Like context menus and the title bar for an opened .py file

Also use custom `vscode-jupytext.resourceLangIds` context to dedupe `when` clauses in `package.json